### PR TITLE
Add `.gitignore` for generated directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Add `.gitignore` file to ignore the `node_modules` directory generated by node.